### PR TITLE
Rename print() method in Msg class to print_()

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ _str1001 = '''
 　　　　　　　 （　　＿　　 ,､'"　　 ￣
 　　　　　　　　 `ー--─'"
 千本目の蝋燭が消えますた・・・
-新しい蝋燭を立ててくださいです・・・ 
+新しい蝋燭を立ててくださいです・・・
 '''
 
 def make_user_dict():
@@ -102,7 +102,7 @@ else:
                 dic[msg.user] = msg.user
             output_file.write('名前: {0} : {1} ID:{2}'.format(dic[msg.user], time.strftime("%Y/%m/%d %a %H:%M:%S", time.localtime(float(msg.ts))), msg.user) + '\n')
             output_file.write('\t' + msg.getTextAs2CH() + '\n')
-            #msg.print(dic)
+            #msg.print_(dic)
         if len(l) == 1000:
             output_file.write('1001 ：１００１：Over 1000 Thread \n')
             output_file.write(_str1001)

--- a/msg.py
+++ b/msg.py
@@ -7,6 +7,6 @@ class Msg:
         self.subtype = subtype
     def getTextAs2CH(self):
         return self.text.replace('\n', '\n\t')
-    def print(self, dic):
+    def print_(self, dic):
         print('名前: {0} : {1} ID:{2}'.format(dic[self.user], time.strftime("%Y/%m/%d %a %H:%M:%S", time.localtime(float(self.ts))), self.user))
         print('\t' + self.getTextAs2CH())


### PR DESCRIPTION
It is a better practice to name the print() method in Msg to other name as it would collide with the print() function in the standard python library.
In this pull request the method is changed to print_().
